### PR TITLE
Fix: Wrong File Path generated on different usecases

### DIFF
--- a/wrap/grpc.go
+++ b/wrap/grpc.go
@@ -73,7 +73,7 @@ func GenerateWrapper(ctx *gofr.Context) (any, error) {
 
 	var (
 		// Extracting package and project path from go_package option.
-		projectPath, packageName = getPackageAndProject(definition)
+		projectPath, packageName = getPackageAndProject(definition, protoPath)
 		// Extract the services.
 		services = getServices(definition)
 	)
@@ -171,11 +171,11 @@ func generategRPCCode(ctx *gofr.Context, data *WrapperData) string {
 	return buf.String()
 }
 
-func getPackageAndProject(definition *proto.Proto) (projectPath, packageName string) {
+func getPackageAndProject(definition *proto.Proto, protoPath string) (projectPath, packageName string) {
 	proto.Walk(definition,
 		proto.WithOption(func(opt *proto.Option) {
 			if opt.Name == "go_package" {
-				projectPath = opt.Constant.Source
+				projectPath = path.Dir(protoPath)
 				packageName = path.Base(opt.Constant.Source)
 			}
 		}),

--- a/wrap/template.go
+++ b/wrap/template.go
@@ -127,7 +127,7 @@ import "gofr.dev/pkg/gofr"
 
 // Register the gRPC service in your app using the following code in your main.go:
 //
-// grpc.Register{{ $.Service }}ServerWithGofr(app, &grpc.{{ $.Service }}GoFrServer{})
+// {{ .Package }}.Register{{ $.Service }}ServerWithGofr(app, &grpc.{{ $.Service }}GoFrServer{})
 //
 // {{ $.Service }}GoFrServer defines the gRPC server implementation.
 // Customize the struct with required dependencies and fields as needed.


### PR DESCRIPTION
Closes #20 

Previously, inconsistencies arose during file path resolution due to varying package names defined in proto files. 

To address this, file path generation now occurs relative to the proto file path. This ensures that files are generated in the same directory as the specified photo file.
 
 