### PR TITLE
Fix: Propagating only metrics while registering gRPC

### DIFF
--- a/wrap/template.go
+++ b/wrap/template.go
@@ -170,6 +170,7 @@ import (
 	"time"
 
 	"gofr.dev/pkg/gofr"
+	"gofr.dev/pkg/gofr/metrics"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -208,15 +209,14 @@ func createGRPCConn(host string) (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
-func New{{ .Service }}GoFrClient(host string, app *gofr.App) (*{{ .Service }}ClientWrapper, error) {
+func New{{ .Service }}GoFrClient(host string, metrics metrics.Manager) (*{{ .Service }}ClientWrapper, error) {
 	conn, err := createGRPCConn(host)
 	if err != nil {
 		return &{{ .Service }}ClientWrapper{client: nil}, err
 	}
 	
 	gRPCBuckets := []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
-	app.Metrics().NewHistogram("app_gRPC-Client_stats", "Response time of gRPC client in milliseconds.", gRPCBuckets...)
-
+	metrics.NewHistogram("app_gRPC-Client_stats", "Response time of gRPC client in milliseconds.", gRPCBuckets...)
 
 	res := New{{ .Service }}Client(conn)
 	return &{{ .Service }}ClientWrapper{


### PR DESCRIPTION
- Propagating only metrics while registering gRPC while generating the gRPC client template.