### PR TITLE
Prevent existing mapping in all.go from changing while adding new migration entry

### DIFF
--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -1,9 +1,11 @@
 package migration
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 	"time"
@@ -12,12 +14,15 @@ import (
 )
 
 const (
-	mig     = "migrations"
-	allFile = "all.go"
+	mig         = "migrations"
+	allFile     = "all.go"
+	matchLength = 3
 )
 
 var (
-	errNameEmpty = errors.New(`please provide the name of the migration using "-name" option`)
+	errNameEmpty    = errors.New(`please provide the name of the migration using "-name" option`)
+	errScanningFile = errors.New("failed to scan existing all.go file")
+	migRegex        = regexp.MustCompile(`^\s*(\d+)\s*:\s*([a-zA-Z_]+)\(\),?\s*$`)
 )
 
 //nolint:gochecknoglobals // keeping them local so that they are computed at the compile time.
@@ -38,9 +43,8 @@ func All() map[int64]migration.Migrate {
 }
 `))
 
-	migrationTemplate = template.Must(template.New("migrationContent").
-				Parse(
-			`package migrations
+	migrationTemplate = template.Must(template.New("migrationContent").Parse(
+		`package migrations
 
 import (
 	"gofr.dev/pkg/gofr/migration"
@@ -107,6 +111,13 @@ func createMigrationFile(ctx *gofr.Context, migrationName string) error {
 }
 
 func createAllMigration(ctx *gofr.Context) error {
+	existing := make(map[string]string)
+
+	existing, err := getAllExistingMigrations(ctx, existing)
+	if err != nil {
+		return err
+	}
+
 	f, err := ctx.File.Create(allFile)
 	if err != nil {
 		return err
@@ -117,14 +128,50 @@ func createAllMigration(ctx *gofr.Context) error {
 		return err
 	}
 
-	migrations := findMigrations(d)
+	currentMigs := findMigrations(d)
 
-	err = allTemplate.Execute(f, migrations)
+	// Merge new migrations into existing map
+	for ts, fn := range currentMigs {
+		if _, ok := existing[ts]; !ok {
+			existing[ts] = fn
+		}
+	}
+
+	err = allTemplate.Execute(f, existing)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func getAllExistingMigrations(ctx *gofr.Context, existing map[string]string) (map[string]string, error) {
+	if _, err := os.Stat(allFile); err == nil {
+		file, err := ctx.File.OpenFile(allFile, os.O_RDONLY, os.ModePerm)
+		if err != nil {
+			return nil, err
+		}
+
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+
+			matches := migRegex.FindStringSubmatch(line)
+			if len(matches) == matchLength {
+				timestamp := matches[1]
+				funcName := matches[2]
+				existing[timestamp] = funcName
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("%w: %w", errScanningFile, err)
+		}
+	}
+
+	return existing, nil
 }
 
 func findMigrations(files []os.DirEntry) map[string]string {


### PR DESCRIPTION
- Closes #35 
- New behavior : Existing mappings in all.go remain unchanged. If the migration file name or function corresponding to an existing timestamp is renamed, all.go will not regenerate or update that entry. Only new migration files—those with timestamps not already present—will be appended to the file during generation.
   