### PR TITLE
Release v0.7.1

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 // CLIVersion is a constant that defines the current version of the CLI application.
-const CLIVersion = "v0.7.0"
+const CLIVersion = "v0.7.1"


### PR DESCRIPTION
# v0.7.1

## 🔧 Fixes

### 1.  **Preserve Existing Mappings in `all.go` During Migration Generation**

The  `migrate`  command previously  **overwrote**  the  `all.go`  file completely, causing renamed or manually modified entries to be lost. This fix updates the behavior to ensure a safer and non-destructive migration experience.

### 🔧 New Behavior:
-   Existing mappings in  `all.go`  are  **left unchanged**.
-   Renamed migration files **do not cause all.go to be overwritten**.
-   Only **new migration files**—identified by  **timestamp-based filenames not yet present**—are  **appended**  to  `all.go`.
    
This fix ensures reliable migration file management without disrupting existing mappings or manual edits.
