### PR TITLE
fix(wrap): extend generated gRPC histogram buckets to 3 minutes

### DIFF
--- a/wrap/template.go
+++ b/wrap/template.go
@@ -565,7 +565,10 @@ func registerServerWithGofr(app *gofr.App, srv any, registerFunc func(grpc.Servi
 
 	// Register metrics and health server only once
 	if !healthServerRegistered {
-		gRPCBuckets := []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
+		gRPCBuckets := []float64{
+			0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10, // 5µs-10ms
+			25, 50, 100, 250, 500, 1000, 5000, 10000, 30000, 60000, 120000, 180000, // 25ms-3min
+		}
 		app.Metrics().NewHistogram("app_gRPC-Server_stats", "Response time of gRPC server in milliseconds.", gRPCBuckets...)
 		app.Metrics().NewHistogram("app_gRPC-Stream_stats", "Duration of gRPC stream in milliseconds.", gRPCBuckets...)
 
@@ -655,7 +658,10 @@ import (
 
 var (
 	metricsOnce sync.Once
-	gRPCBuckets = []float64{0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10}
+	gRPCBuckets = []float64{
+		0.005, 0.01, .05, .075, .1, .125, .15, .2, .3, .5, .75, 1, 2, 3, 4, 5, 7.5, 10, // 5µs-10ms
+		25, 50, 100, 250, 500, 1000, 5000, 10000, 30000, 60000, 120000, 180000, // 25ms-3min
+	}
 )
 
 type HealthClient interface {


### PR DESCRIPTION
## What

The gRPC latency histograms emitted by `gofr wrap grpc` (`app_gRPC-Server_stats`, `app_gRPC-Stream_stats`, `app_gRPC-Client_stats`) capped their buckets at `10` (ms). Any RPC slower than 10ms fell into the `+Inf` bucket, so the histogram carried no usable distribution above that point.

This extends the generated `gRPCBuckets` (both the server-side and client-side templates in `wrap/template.go`) up to `180000` (3 minutes), keeping the existing fine-grained low end (`0.005`…`10`).

gRPC duration is recorded in **fractional milliseconds** (`durationMs` in gofr's `pkg/gofr/grpc`), so the buckets remain in milliseconds and the existing `"... in milliseconds."` descriptions stay correct — only the range grows.

## Why now

Companion to gofr-dev/gofr#3568, which extends all **datasource** latency histograms to 3 minutes. gRPC histograms are generated by this CLI (the gofr repo only ships generated `// DO NOT EDIT` examples), so the fix belongs here.

## Compatibility

No recorded values change; only histogram bucket boundaries are added. Existing services pick up the new buckets when they regenerate their gRPC wrappers.

## Note

Regenerate the committed gRPC examples in the gofr repo (or let them be regenerated) so they reflect the new buckets.