### PR TITLE
Fix naming conventions for generated gRPC templates

### DIFF
--- a/wrap/template.go
+++ b/wrap/template.go
@@ -14,22 +14,33 @@ const (
     {{- end }}
 {{- end }}
 
+{{- $hasStream := false }}
+{{- range .Methods }}
+    {{- if or .StreamsRequest .StreamsResponse }}
+        {{- $hasStream = true }}
+    {{- end }}
+{{- end }}
+
 package {{ .Package }}
 
 import (
 	"context"
+	{{- if $hasStream }}
 	"time"
-	
+	{{- end }}
+
 	"gofr.dev/pkg/gofr"
 	"gofr.dev/pkg/gofr/container"
+	{{- if $hasStream }}
 	gofrgRPC "gofr.dev/pkg/gofr/grpc"
+	{{- end }}
 	"google.golang.org/grpc"
 
 	{{- if $hasUnary }}
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	{{- end }}
-	
+
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -58,13 +69,6 @@ type {{ .Service }}ServiceWrapper struct {
 	Container *container.Container
 	server    {{ .Service }}ServiceWithGofr
 }
-
-{{- $hasStream := false }}
-{{- range .Methods }}
-    {{- if or .StreamsRequest .StreamsResponse }}
-        {{- $hasStream = true }}
-    {{- end }}
-{{- end }}
 
 {{- if $hasStream }}
 // Base instrumented stream
@@ -328,30 +332,30 @@ import (
 
 // Request Wrappers
 {{- range $request := .Requests }}
-type {{ $request }}Wrapper struct {
+type {{ $request.Request }}Wrapper struct {
 	ctx context.Context
-	*{{ $request }}
+	*{{ $request.Request }}
 }
 
-func (h *{{ $request }}Wrapper) Context() context.Context {
+func (h *{{ $request.Request }}Wrapper) Context() context.Context {
 	return h.ctx
 }
 
-func (h *{{ $request }}Wrapper) Param(s string) string {
+func (h *{{ $request.Request }}Wrapper) Param(s string) string {
 	return ""
 }
 
-func (h *{{ $request }}Wrapper) PathParam(s string) string {
+func (h *{{ $request.Request }}Wrapper) PathParam(s string) string {
 	return ""
 }
 
-func (h *{{ $request }}Wrapper) Bind(p interface{}) error {
+func (h *{{ $request.Request }}Wrapper) Bind(p interface{}) error {
 	ptr := reflect.ValueOf(p)
 	if ptr.Kind() != reflect.Ptr {
 		return fmt.Errorf("expected a pointer, got %T", p)
 	}
 
-	hValue := reflect.ValueOf(h.{{ $request }}).Elem()
+	hValue := reflect.ValueOf(h.{{ $request.Request }}).Elem()
 	ptrValue := ptr.Elem()
 
 	for i := 0; i < hValue.NumField(); i++ {
@@ -368,11 +372,11 @@ func (h *{{ $request }}Wrapper) Bind(p interface{}) error {
 	return nil
 }
 
-func (h *{{ $request }}Wrapper) HostName() string {
+func (h *{{ $request.Request }}Wrapper) HostName() string {
 	return ""
 }
 
-func (h *{{ $request }}Wrapper) Params(s string) []string {
+func (h *{{ $request.Request }}Wrapper) Params(s string) []string {
 	return nil
 }
 {{- end }}`

--- a/wrap/template.go
+++ b/wrap/template.go
@@ -14,33 +14,22 @@ const (
     {{- end }}
 {{- end }}
 
-{{- $hasStream := false }}
-{{- range .Methods }}
-    {{- if or .StreamsRequest .StreamsResponse }}
-        {{- $hasStream = true }}
-    {{- end }}
-{{- end }}
-
 package {{ .Package }}
 
 import (
 	"context"
-	{{- if $hasStream }}
 	"time"
-	{{- end }}
-
+	
 	"gofr.dev/pkg/gofr"
 	"gofr.dev/pkg/gofr/container"
-	{{- if $hasStream }}
 	gofrgRPC "gofr.dev/pkg/gofr/grpc"
-	{{- end }}
 	"google.golang.org/grpc"
 
 	{{- if $hasUnary }}
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	{{- end }}
-
+	
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -69,6 +58,13 @@ type {{ .Service }}ServiceWrapper struct {
 	Container *container.Container
 	server    {{ .Service }}ServiceWithGofr
 }
+
+{{- $hasStream := false }}
+{{- range .Methods }}
+    {{- if or .StreamsRequest .StreamsResponse }}
+        {{- $hasStream = true }}
+    {{- end }}
+{{- end }}
 
 {{- if $hasStream }}
 // Base instrumented stream
@@ -332,30 +328,30 @@ import (
 
 // Request Wrappers
 {{- range $request := .Requests }}
-type {{ $request.Request }}Wrapper struct {
+type {{ $request }}Wrapper struct {
 	ctx context.Context
-	*{{ $request.Request }}
+	*{{ $request }}
 }
 
-func (h *{{ $request.Request }}Wrapper) Context() context.Context {
+func (h *{{ $request }}Wrapper) Context() context.Context {
 	return h.ctx
 }
 
-func (h *{{ $request.Request }}Wrapper) Param(s string) string {
+func (h *{{ $request }}Wrapper) Param(s string) string {
 	return ""
 }
 
-func (h *{{ $request.Request }}Wrapper) PathParam(s string) string {
+func (h *{{ $request }}Wrapper) PathParam(s string) string {
 	return ""
 }
 
-func (h *{{ $request.Request }}Wrapper) Bind(p interface{}) error {
+func (h *{{ $request }}Wrapper) Bind(p interface{}) error {
 	ptr := reflect.ValueOf(p)
 	if ptr.Kind() != reflect.Ptr {
 		return fmt.Errorf("expected a pointer, got %T", p)
 	}
 
-	hValue := reflect.ValueOf(h.{{ $request.Request }}).Elem()
+	hValue := reflect.ValueOf(h.{{ $request }}).Elem()
 	ptrValue := ptr.Elem()
 
 	for i := 0; i < hValue.NumField(); i++ {
@@ -372,11 +368,11 @@ func (h *{{ $request.Request }}Wrapper) Bind(p interface{}) error {
 	return nil
 }
 
-func (h *{{ $request.Request }}Wrapper) HostName() string {
+func (h *{{ $request }}Wrapper) HostName() string {
 	return ""
 }
 
-func (h *{{ $request.Request }}Wrapper) Params(s string) []string {
+func (h *{{ $request }}Wrapper) Params(s string) []string {
 	return nil
 }
 {{- end }}`

--- a/wrap/template.go
+++ b/wrap/template.go
@@ -33,15 +33,15 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
-// New{{ .Service }}GoFrServer creates a new instance of {{ .Service }}GoFrServer
-func New{{ .Service }}GoFrServer() *{{ .Service }}GoFrServer {
-	return &{{ .Service }}GoFrServer{
+// New{{ .Service }}GoFrService creates a new instance of {{ .Service }}GoFrService
+func New{{ .Service }}GoFrService() *{{ .Service }}GoFrService {
+	return &{{ .Service }}GoFrService{
 		health: getOrCreateHealthServer(), // Initialize the health server
 	}
 }
 
-// {{ .Service }}ServerWithGofr is the interface for the server implementation
-type {{ .Service }}ServerWithGofr interface {
+// {{ .Service }}ServiceWithGofr is the interface for the server implementation
+type {{ .Service }}ServiceWithGofr interface {
 {{- range .Methods }}
 {{- if or .StreamsRequest .StreamsResponse }}
 	{{ .Name }}(*gofr.Context, {{ $.Service }}_{{ .Name }}Server) error
@@ -51,12 +51,12 @@ type {{ .Service }}ServerWithGofr interface {
 {{- end }}
 }
 
-// {{ .Service }}ServerWrapper wraps the server and handles request and response logic
-type {{ .Service }}ServerWrapper struct {
+// {{ .Service }}ServiceWrapper wraps the server and handles request and response logic
+type {{ .Service }}ServiceWrapper struct {
 	{{ .Service }}Server
 	*healthServer
 	Container *container.Container
-	server    {{ .Service }}ServerWithGofr
+	server    {{ .Service }}ServiceWithGofr
 }
 
 {{- $hasStream := false }}
@@ -220,7 +220,7 @@ func (w *bidiStreamWrapper{{ .Name }}) CloseSend() error {
 {{- if .StreamsResponse }}
 {{- if not .StreamsRequest }}
 // Server-side streaming handler for {{ .Name }}
-func (h *{{ $.Service }}ServerWrapper) {{ .Name }}(req *{{ .Request }}, stream {{ $.Service }}_{{ .Name }}Server) error {
+func (h *{{ $.Service }}ServiceWrapper) {{ .Name }}(req *{{ .Request }}, stream {{ $.Service }}_{{ .Name }}Server) error {
 	ctx := stream.Context()
 	gctx := h.getGofrContext(ctx, &{{ .Request }}Wrapper{ctx: ctx, {{ .Request }}: req})
 	
@@ -235,7 +235,7 @@ func (h *{{ $.Service }}ServerWrapper) {{ .Name }}(req *{{ .Request }}, stream {
 }
 {{- else }}
 // Bidirectional streaming handler for {{ .Name }}
-func (h *{{ $.Service }}ServerWrapper) {{ .Name }}(stream {{ $.Service }}_{{ .Name }}Server) error {
+func (h *{{ $.Service }}ServiceWrapper) {{ .Name }}(stream {{ $.Service }}_{{ .Name }}Server) error {
 	ctx := stream.Context()
 	gctx := h.getGofrContext(ctx, nil)
 	
@@ -251,7 +251,7 @@ func (h *{{ $.Service }}ServerWrapper) {{ .Name }}(stream {{ $.Service }}_{{ .Na
 {{- end }}
 {{- else if .StreamsRequest }}
 // Client-side streaming handler for {{ .Name }}
-func (h *{{ $.Service }}ServerWrapper) {{ .Name }}(stream {{ $.Service }}_{{ .Name }}Server) error {
+func (h *{{ $.Service }}ServiceWrapper) {{ .Name }}(stream {{ $.Service }}_{{ .Name }}Server) error {
 	ctx := stream.Context()
 	gctx := h.getGofrContext(ctx, nil)
 	
@@ -266,7 +266,7 @@ func (h *{{ $.Service }}ServerWrapper) {{ .Name }}(stream {{ $.Service }}_{{ .Na
 }
 {{- else }}
 // Unary method handler for {{ .Name }}
-func (h *{{ $.Service }}ServerWrapper) {{ .Name }}(ctx context.Context, req *{{ .Request }}) (*{{ .Response }}, error) {
+func (h *{{ $.Service }}ServiceWrapper) {{ .Name }}(ctx context.Context, req *{{ .Request }}) (*{{ .Response }}, error) {
 	gctx := h.getGofrContext(ctx, &{{ .Request }}Wrapper{ctx: ctx, {{ .Request }}: req})
 	
 	res, err := h.server.{{ .Name }}(gctx)
@@ -285,13 +285,13 @@ func (h *{{ $.Service }}ServerWrapper) {{ .Name }}(ctx context.Context, req *{{ 
 {{- end }}
 
 // mustEmbedUnimplemented{{ .Service }}Server ensures implementation
-func (h *{{ .Service }}ServerWrapper) mustEmbedUnimplemented{{ .Service }}Server() {}
+func (h *{{ .Service }}ServiceWrapper) mustEmbedUnimplemented{{ .Service }}Server() {}
 
-// Register{{ .Service }}ServerWithGofr registers the server
-func Register{{ .Service }}ServerWithGofr(app *gofr.App, srv {{ .Service }}ServerWithGofr) {
+// Register{{ .Service }}ServiceWithGofr registers the server
+func Register{{ .Service }}ServiceWithGofr(app *gofr.App, srv {{ .Service }}ServiceWithGofr) {
 	registerServerWithGofr(app, srv, func(s grpc.ServiceRegistrar, srv any) {
-		wrapper := &{{ .Service }}ServerWrapper{
-			server: srv.({{ .Service }}ServerWithGofr),
+		wrapper := &{{ .Service }}ServiceWrapper{
+			server: srv.({{ .Service }}ServiceWithGofr),
 			healthServer: getOrCreateHealthServer(),
 		}
 
@@ -302,7 +302,7 @@ func Register{{ .Service }}ServerWithGofr(app *gofr.App, srv {{ .Service }}Serve
 }
 
 // getGofrContext creates GoFr context
-func (h *{{ .Service }}ServerWrapper) getGofrContext(ctx context.Context, req gofr.Request) *gofr.Context {
+func (h *{{ .Service }}ServiceWrapper) getGofrContext(ctx context.Context, req gofr.Request) *gofr.Context {
 	return &gofr.Context{
 		Context:   ctx,
 		Container: h.Container,
@@ -388,28 +388,28 @@ import "gofr.dev/pkg/gofr"
 
 // Register the gRPC service in your app using the following code in your main.go:
 //
-// {{ .Package }}.Register{{ $.Service }}ServerWithGofr(app, &{{ .Package }}.New{{ $.Service }}GoFrServer())
+// {{ .Package }}.Register{{ $.Service }}ServiceWithGofr(app, &{{ .Package }}.New{{ $.Service }}GoFrService())
 //
-// {{ $.Service }}GoFrServer defines the gRPC server implementation.
+// {{ $.Service }}GoFrService defines the gRPC server implementation.
 // Customize the struct with required dependencies and fields as needed.
 
-type {{ $.Service }}GoFrServer struct {
+type {{ $.Service }}GoFrService struct {
  health *healthServer
 }
 
 {{- range .Methods }}
 {{- if .StreamsRequest }}
-func (s *{{ $.Service }}GoFrServer) {{ .Name }}(ctx *gofr.Context, stream {{ $.Service }}_{{ .Name }}Server) error {
+func (s *{{ $.Service }}GoFrService) {{ .Name }}(ctx *gofr.Context, stream {{ $.Service }}_{{ .Name }}Server) error {
 	// Implementation here
 	return nil
 }
 {{- else if .StreamsResponse }}
-func (s *{{ $.Service }}GoFrServer) {{ .Name }}(ctx *gofr.Context, stream {{ $.Service }}_{{ .Name }}Server) error {
+func (s *{{ $.Service }}GoFrService) {{ .Name }}(ctx *gofr.Context, stream {{ $.Service }}_{{ .Name }}Server) error {
 	// Implementation here
 	return nil
 }
 {{- else }}
-func (s *{{ $.Service }}GoFrServer) {{ .Name }}(ctx *gofr.Context) (any, error) {
+func (s *{{ $.Service }}GoFrService) {{ .Name }}(ctx *gofr.Context) (any, error) {
 	return &{{ .Response }}{}, nil
 }
 {{- end }}

--- a/wrap/template_test.go
+++ b/wrap/template_test.go
@@ -1,0 +1,106 @@
+package wrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gofr.dev/pkg/gofr"
+	"gofr.dev/pkg/gofr/cmd"
+	gofrConfig "gofr.dev/pkg/gofr/config"
+	"gofr.dev/pkg/gofr/container"
+	"gofr.dev/pkg/gofr/logging"
+)
+
+// createTestContext creates a test gofr.Context for CMD applications.
+func createTestContext() *gofr.Context {
+	c := container.NewContainer(gofrConfig.NewEnvFile("", logging.NewMockLogger(logging.DEBUG)))
+	req := cmd.NewRequest([]string{})
+
+	return &gofr.Context{
+		Context:   req.Context(),
+		Request:   req,
+		Container: c,
+	}
+}
+
+// testWrapperData returns a service with one unary and one server-streaming
+// method, enough to exercise every naming path in the templates.
+func testWrapperData() *WrapperData {
+	return &WrapperData{
+		Package: "hello",
+		Service: "Hello",
+		Source:  "hello.proto",
+		Methods: []ServiceMethod{
+			{Name: "SayHello", Request: "HelloRequest", Response: "HelloResponse"},
+			{Name: "LotsOfReplies", Request: "HelloRequest", Response: "HelloResponse", StreamsResponse: true},
+		},
+		Requests: []ServiceRequest{{Request: "HelloRequest"}},
+	}
+}
+
+// The generated GoFr wrapper must name the CLI's own types after the service
+// (issue #40): Register<Svc>ServiceWithGofr / <Svc>GoFrService, not ...Server...
+// The protoc-gen-go-grpc contract symbols the wrapper references must stay
+// exactly as protoc emits them, otherwise the generated code won't compile.
+func TestGenerateGoFrServerWrapper_Naming(t *testing.T) {
+	out := generateGoFrServerWrapper(createTestContext(), testWrapperData())
+
+	wantService := []string{
+		"func NewHelloGoFrService() *HelloGoFrService {",
+		"type HelloServiceWithGofr interface {",
+		"type HelloServiceWrapper struct {",
+		"func RegisterHelloServiceWithGofr(app *gofr.App, srv HelloServiceWithGofr) {",
+		"func (h *HelloServiceWrapper) SayHello(",
+	}
+	for _, s := range wantService {
+		assert.Contains(t, out, s, "CLI-owned type must be renamed to Service")
+	}
+
+	wantProtoc := []string{
+		"mustEmbedUnimplementedHelloServer()", // required method of protoc HelloServer
+		"RegisterHelloServer(s, wrapper)",     // protoc registration func
+		"Hello_LotsOfRepliesServer",           // protoc stream interface
+		"registerServerWithGofr(app, srv,",    // generic CLI helper, not service-scoped
+	}
+	for _, s := range wantProtoc {
+		assert.Contains(t, out, s, "protoc/contract symbol must be left unchanged")
+	}
+
+	// The old CLI names must be gone entirely.
+	for _, s := range []string{"NewHelloGoFrServer", "HelloServerWithGofr", "HelloServerWrapper", "RegisterHelloServerWithGofr"} {
+		assert.NotContains(t, out, s, "old Server-suffixed CLI name must not remain")
+	}
+}
+
+// The server scaffold users edit must expose the renamed struct + usage hint.
+func TestGenerateGoFrServer_Naming(t *testing.T) {
+	out := generateGoFrServer(createTestContext(), testWrapperData())
+
+	for _, s := range []string{
+		"type HelloGoFrService struct {",
+		"func (s *HelloGoFrService) SayHello(",
+		"RegisterHelloServiceWithGofr(app,",
+		"NewHelloGoFrService()",
+	} {
+		assert.Contains(t, out, s)
+	}
+
+	// Streaming handler still references the protoc stream type.
+	assert.Contains(t, out, "Hello_LotsOfRepliesServer")
+	assert.NotContains(t, out, "HelloGoFrServer")
+}
+
+// The client template is unrelated to the Server->Service rename and must keep
+// its GoFrClient / protoc client naming intact.
+func TestGenerateGoFrClient_NamingUnaffected(t *testing.T) {
+	out := generateGoFrClient(createTestContext(), testWrapperData())
+
+	for _, s := range []string{
+		"type HelloGoFrClient interface {",
+		"type HelloClientWrapper struct {",
+		"func NewHelloGoFrClient(",
+		"NewHelloClient(conn)", // protoc client constructor
+	} {
+		assert.Contains(t, out, s)
+	}
+}

--- a/wrap/template_test.go
+++ b/wrap/template_test.go
@@ -90,6 +90,43 @@ func TestGenerateGoFrServer_Naming(t *testing.T) {
 	assert.NotContains(t, out, "HelloGoFrServer")
 }
 
+// unaryOnlyData is a service with no streaming methods, to exercise the
+// stream-only import gating.
+func unaryOnlyData() *WrapperData {
+	return &WrapperData{
+		Package:  "hello",
+		Service:  "Hello",
+		Source:   "hello.proto",
+		Methods:  []ServiceMethod{{Name: "SayHello", Request: "HelloRequest", Response: "HelloResponse"}},
+		Requests: []ServiceRequest{{Request: "HelloRequest"}},
+	}
+}
+
+// The request wrapper must be named after the request type, not the printed
+// ServiceRequest struct (which produced "{HelloRequest HelloRequest}Wrapper"
+// and broke compilation). Found while running the generated server end-to-end.
+func TestGenerateGoFrRequestWrapper_UsesRequestName(t *testing.T) {
+	out := generateGoFrRequestWrapper(createTestContext(), testWrapperData())
+
+	assert.Contains(t, out, "type HelloRequestWrapper struct {")
+	assert.Contains(t, out, "*HelloRequest")
+	assert.NotContains(t, out, "{HelloRequest", "the ServiceRequest struct must not be printed verbatim")
+}
+
+// time and the gofr gRPC logger are only used by the streaming instrumentation,
+// so they must be imported only when the service has a streaming method —
+// otherwise a unary-only service fails to compile with "imported and not used".
+// Found while running the generated server end-to-end.
+func TestServerWrapperImports_GatedOnStreaming(t *testing.T) {
+	streaming := generateGoFrServerWrapper(createTestContext(), testWrapperData())
+	assert.Contains(t, streaming, `"time"`)
+	assert.Contains(t, streaming, "gofrgRPC")
+
+	unary := generateGoFrServerWrapper(createTestContext(), unaryOnlyData())
+	assert.NotContains(t, unary, `"time"`, "unary-only service must not import the stream-only time dep")
+	assert.NotContains(t, unary, "gofrgRPC", "unary-only service must not import the stream-only gRPC logger")
+}
+
 // The client template is unrelated to the Server->Service rename and must keep
 // its GoFrClient / protoc client naming intact.
 func TestGenerateGoFrClient_NamingUnaffected(t *testing.T) {

--- a/wrap/template_test.go
+++ b/wrap/template_test.go
@@ -90,43 +90,6 @@ func TestGenerateGoFrServer_Naming(t *testing.T) {
 	assert.NotContains(t, out, "HelloGoFrServer")
 }
 
-// unaryOnlyData is a service with no streaming methods, to exercise the
-// stream-only import gating.
-func unaryOnlyData() *WrapperData {
-	return &WrapperData{
-		Package:  "hello",
-		Service:  "Hello",
-		Source:   "hello.proto",
-		Methods:  []ServiceMethod{{Name: "SayHello", Request: "HelloRequest", Response: "HelloResponse"}},
-		Requests: []ServiceRequest{{Request: "HelloRequest"}},
-	}
-}
-
-// The request wrapper must be named after the request type, not the printed
-// ServiceRequest struct (which produced "{HelloRequest HelloRequest}Wrapper"
-// and broke compilation). Found while running the generated server end-to-end.
-func TestGenerateGoFrRequestWrapper_UsesRequestName(t *testing.T) {
-	out := generateGoFrRequestWrapper(createTestContext(), testWrapperData())
-
-	assert.Contains(t, out, "type HelloRequestWrapper struct {")
-	assert.Contains(t, out, "*HelloRequest")
-	assert.NotContains(t, out, "{HelloRequest", "the ServiceRequest struct must not be printed verbatim")
-}
-
-// time and the gofr gRPC logger are only used by the streaming instrumentation,
-// so they must be imported only when the service has a streaming method —
-// otherwise a unary-only service fails to compile with "imported and not used".
-// Found while running the generated server end-to-end.
-func TestServerWrapperImports_GatedOnStreaming(t *testing.T) {
-	streaming := generateGoFrServerWrapper(createTestContext(), testWrapperData())
-	assert.Contains(t, streaming, `"time"`)
-	assert.Contains(t, streaming, "gofrgRPC")
-
-	unary := generateGoFrServerWrapper(createTestContext(), unaryOnlyData())
-	assert.NotContains(t, unary, `"time"`, "unary-only service must not import the stream-only time dep")
-	assert.NotContains(t, unary, "gofrgRPC", "unary-only service must not import the stream-only gRPC logger")
-}
-
 // The client template is unrelated to the Server->Service rename and must keep
 // its GoFrClient / protoc client naming intact.
 func TestGenerateGoFrClient_NamingUnaffected(t *testing.T) {


### PR DESCRIPTION
## Objective

Resolves #40 — the generated GoFr gRPC wrapper names the CLI's own service types with a `Server` suffix; rename them to `Service`.

```go
// before
server.RegisterHelloServerWithGofr(app, server.NewHelloGoFrServer())
// after
server.RegisterHelloServiceWithGofr(app, server.NewHelloGoFrService())
```

## What changed

Renamed the CLI-owned identifiers in `wrap/template.go` from `Server` → `Service`:

| Before | After |
| --- | --- |
| `{{.Service}}GoFrServer` | `{{.Service}}GoFrService` |
| `{{.Service}}ServerWithGofr` | `{{.Service}}ServiceWithGofr` |
| `{{.Service}}ServerWrapper` | `{{.Service}}ServiceWrapper` |
| `Register{{.Service}}ServerWithGofr` | `Register{{.Service}}ServiceWithGofr` |

**Left as `Server`** (protoc-gen-go-grpc contract symbols the generated code references): embedded `{{.Service}}Server`, `mustEmbedUnimplemented{{.Service}}Server()`, `Register{{.Service}}Server(...)`, `{{.Service}}_{{.Name}}Server` streams, `{{.Service}}Client`/`New{{.Service}}Client(...)`, the generic helper `registerServerWithGofr`, and `grpc.ServerStream`. The client template needed no change.

## Tests

Adds `wrap/template_test.go` (first coverage for the package) asserting the CLI-owned types are service-named and the old names are gone, while every protoc contract symbol is preserved, and the client surface is unaffected.

## Test plan

- `go test ./...` — all pass, incl. the new `wrap` naming tests.
- `gofmt` / `go vet ./...` clean.

## Scope note

This PR is now **naming-only**. Two unrelated code-generation bugs I'd originally bundled here were split out so each fix is independently mergeable:
- the request-wrapper struct-literal leak → **#82** (fixes #75).
- a unary-only "imported and not used" (`time`/`gofrgRPC`) bug → still unfiled; happy to open a separate issue/PR.